### PR TITLE
Various dummydroid fixes/improvements

### DIFF
--- a/src/main/java/com/akdeniz/googleplaycrawler/GooglePlayAPI.java
+++ b/src/main/java/com/akdeniz/googleplaycrawler/GooglePlayAPI.java
@@ -156,7 +156,7 @@ public class GooglePlayAPI {
 		// this first checkin is for generating android-id
 		AndroidCheckinResponse checkinResponse = postCheckin(Utils.generateAndroidCheckinRequest()
 				.toByteArray());
-		this.setAndroidID(BigInteger.valueOf(checkinResponse.getAndroidId()).toString(16));
+		this.setAndroidID(BigInteger.valueOf(checkinResponse.getAndroidId()).toString(16).toUpperCase());
 		setSecurityToken((BigInteger.valueOf(checkinResponse.getSecurityToken()).toString(16)));
 
 		String c2dmAuth = loginAC2DM();
@@ -202,7 +202,7 @@ public class GooglePlayAPI {
 		String[][] data = new String[][] {
 				{ "app", application },
 				{ "sender", sender },
-				{ "device", new BigInteger(this.getAndroidID(), 16).toString() } };
+				{ "device", new BigInteger(this.getAndroidID(), 16).toString().toUpperCase() } };
 		HttpEntity responseEntity = executePost(C2DM_REGISTER_URL, data,
 				getHeaderParameters(c2dmAuth, null));
 		return Utils.parseResponse(new String(Utils.readAll(responseEntity.getContent())));

--- a/src/main/java/com/akdeniz/googleplaycrawler/GooglePlayAPI.java
+++ b/src/main/java/com/akdeniz/googleplaycrawler/GooglePlayAPI.java
@@ -188,7 +188,7 @@ public class GooglePlayAPI {
 						{ "device_country", "us" },
 						{ "device_country", "us" },
 						{ "lang", "en" },
-						{ "sdk_version", "21" }, }, null);
+						{ "sdk_version", "17" }, }, null);
 
 		Map<String, String> c2dmAuth = Utils.parseResponse(new String(Utils.readAll(c2dmResponseEntity
 				.getContent())));
@@ -234,7 +234,7 @@ public class GooglePlayAPI {
 				{ "app", "com.android.vending" },
 				{ "device_country", "en" },
 				{ "lang", "en" },
-				{ "sdk_version", "21" }, }, null);
+				{ "sdk_version", "17" }, }, null);
 
 		Map<String, String> response = Utils.parseResponse(new String(Utils.readAll(responseEntity
 				.getContent())));
@@ -600,7 +600,7 @@ public class GooglePlayAPI {
 				{ "X-DFE-Client-Id", "am-android-google" },
 				{
 						"User-Agent",
-						"Android-Finsky/6.7.07.E (api=3,versionCode=80670700,sdk=23,device=angler,hardware=angler,product=angler,build=MTC19T:user)" },
+						"Android-Finsky/6.7.07.E (versionCode=80670700,sdk=23,device=angler,hardware=angler,product=angler,build=MTC19T:user)" },
 				{ "X-DFE-SmallestScreenWidthDp", "320" },
 				{ "X-DFE-Filter-Level", "3" },
 				{ "Host", "android.clients.google.com" },

--- a/src/main/java/com/akdeniz/googleplaycrawler/GooglePlayAPI.java
+++ b/src/main/java/com/akdeniz/googleplaycrawler/GooglePlayAPI.java
@@ -45,16 +45,16 @@ import com.akdeniz.googleplaycrawler.GooglePlay.UploadDeviceConfigResponse;
  * <code>checkin, search, details, bulkDetails, browse, list and download</code>
  * capabilities. It uses <code>Apache Commons HttpClient</code> for POST and GET
  * requests.
- * 
+ *
  * <p>
  * <b>XXX : DO NOT call checkin, login and download consecutively. To allow
  * server to catch up, sleep for a while before download! (5 sec will do!) Also
  * it is recommended to call checkin once and use generated android-id for
  * further operations.</b>
  * </p>
- * 
+ *
  * @author akdeniz
- * 
+ *
  */
 public class GooglePlayAPI {
 
@@ -131,7 +131,7 @@ public class GooglePlayAPI {
 
 	/**
 	 * Connection manager to allow concurrent connections.
-	 * 
+	 *
 	 * @return {@link ClientConnectionManager} instance
 	 */
 	public static ClientConnectionManager getConnectionManager() {
@@ -145,11 +145,11 @@ public class GooglePlayAPI {
 	/**
 	 * Performs authentication on "ac2dm" service and match up android id,
 	 * security token and email by checking them in on this server.
-	 * 
+	 *
 	 * This function sets check-inded android ID and that can be taken either by
 	 * using <code>getToken()</code> or from returned
 	 * {@link AndroidCheckinResponse} instance.
-	 * 
+	 *
 	 */
 	public AndroidCheckinResponse checkin() throws Exception {
 
@@ -322,7 +322,7 @@ public class GooglePlayAPI {
 	 * Fetches applications within supplied category and sub-category. If
 	 * <code>null</code> is given for sub-category, it fetches sub-categories of
 	 * passed category.
-	 * 
+	 *
 	 * Default values for offset and numberOfResult are "0" and "20" respectively.
 	 * These values are determined by Google Play Store.
 	 */
@@ -400,7 +400,7 @@ public class GooglePlayAPI {
 				{ "Cookie", cookie },
 				{
 						"User-Agent",
-						"AndroidDownloadManager/4.1.1 (Linux; U; Android 4.1.1; Nexus S Build/JRO03E)" }, };
+						"AndroidDownloadManager/6.0.1 (Linux; U; Android 6.0.1; Nexus 6P Build/MTC19T)" }, };
 
 		HttpEntity httpEntity = executeGet(url, null, headerParams);
 		return httpEntity.getContent();
@@ -408,7 +408,7 @@ public class GooglePlayAPI {
 
 	/**
 	 * Fetches the reviews of given package name by sorting passed choice.
-	 * 
+	 *
 	 * Default values for offset and numberOfResult are "0" and "20" respectively.
 	 * These values are determined by Google Play Store.
 	 */
@@ -426,7 +426,7 @@ public class GooglePlayAPI {
 	/**
 	 * Uploads device configuration to google server so that can be seen from web
 	 * as a registered device!!
-	 * 
+	 *
 	 * @see https://play.google.com/store/account
 	 */
 	public UploadDeviceConfigResponse uploadDeviceConfig() throws Exception {
@@ -440,7 +440,7 @@ public class GooglePlayAPI {
 
 	/**
 	 * Fetches the recommendations of given package name.
-	 * 
+	 *
 	 * Default values for offset and numberOfResult are "0" and "20" respectively.
 	 * These values are determined by Google Play Store.
 	 */
@@ -461,7 +461,7 @@ public class GooglePlayAPI {
 	/**
 	 * Executes GET request and returns result as {@link ResponseWrapper}.
 	 * Standard header parameters will be used for request.
-	 * 
+	 *
 	 * @see getHeaderParameters
 	 * */
 	private ResponseWrapper executeGETRequest(String path, String[][] datapost) throws IOException {
@@ -474,7 +474,7 @@ public class GooglePlayAPI {
 	/**
 	 * Executes POST request and returns result as {@link ResponseWrapper}.
 	 * Standard header parameters will be used for request.
-	 * 
+	 *
 	 * @see getHeaderParameters
 	 * */
 	private ResponseWrapper executePOSTRequest(String path, String[][] datapost) throws IOException {
@@ -590,7 +590,7 @@ public class GooglePlayAPI {
 	private String[][] getHeaderParameters(String token, String contentType) {
 
 		return new String[][] {
-				{ "Accept-Language", getLocalization() != null ? getLocalization() : "en-EN" },
+				{ "Accept-Language", getLocalization() != null ? getLocalization() : "en_US" },
 				{ "Authorization", "GoogleLogin auth=" + token },
 				{ "X-DFE-Enabled-Experiments", "cl:billing.select_add_instrument_by_default" },
 				{
@@ -600,7 +600,7 @@ public class GooglePlayAPI {
 				{ "X-DFE-Client-Id", "am-android-google" },
 				{
 						"User-Agent",
-						"Android-Finsky/3.10.14 (api=3,versionCode=8016014,sdk=15,device=GT-I9300,hardware=aries,product=GT-I9300)" },
+						"Android-Finsky/6.7.07.E (api=3,versionCode=80670700,sdk=23,device=angler,hardware=angler,product=angler,build=MTC19T:user)" },
 				{ "X-DFE-SmallestScreenWidthDp", "320" },
 				{ "X-DFE-Filter-Level", "3" },
 				{ "Host", "android.clients.google.com" },
@@ -641,9 +641,9 @@ public class GooglePlayAPI {
 	/**
 	 * Sets {@link HttpClient} instance for internal usage of GooglePlayAPI. It is
 	 * important to note that this instance should allow concurrent connections.
-	 * 
+	 *
 	 * @see getConnectionManager
-	 * 
+	 *
 	 * @param client
 	 */
 	public void setClient(HttpClient client) {
@@ -670,7 +670,7 @@ public class GooglePlayAPI {
 	 * Note that changing this value has no affect on localized application list
 	 * that server provides. It depends on only your IP location.
 	 * <p>
-	 * 
+	 *
 	 * @param localization
 	 *          can be <b>en-EN, en-US, tr-TR, fr-FR ... (default : en-EN)</b>
 	 */

--- a/src/main/java/com/akdeniz/googleplaycrawler/GooglePlayAPI.java
+++ b/src/main/java/com/akdeniz/googleplaycrawler/GooglePlayAPI.java
@@ -181,11 +181,11 @@ public class GooglePlayAPI {
 						{ "Email", this.getEmail() },
 						{ "Passwd", this.password },
 						{ "service", "ac2dm" },
+						{ "add_account", "1"},
 						{ "accountType", ACCOUNT_TYPE_HOSTED_OR_GOOGLE },
 						{ "has_permission", "1" },
 						{ "source", "android" },
 						{ "app", "com.google.android.gsf" },
-						{ "device_country", "us" },
 						{ "device_country", "us" },
 						{ "lang", "en" },
 						{ "sdk_version", "17" }, }, null);
@@ -232,7 +232,7 @@ public class GooglePlayAPI {
 				{ "source", "android" },
 				{ "androidId", this.getAndroidID() },
 				{ "app", "com.android.vending" },
-				{ "device_country", "en" },
+				{ "device_country", "us" },
 				{ "lang", "en" },
 				{ "sdk_version", "17" }, }, null);
 

--- a/src/main/java/com/akdeniz/googleplaycrawler/Utils.java
+++ b/src/main/java/com/akdeniz/googleplaycrawler/Utils.java
@@ -176,7 +176,7 @@ public class Utils {
 						.setProduct("angler").setCarrier("Google").setRadio("angler-03.61")
 						.setBootloader("angler-03.51").setClient("android-google")
 						.setTimestamp(new Date().getTime() / 1000).setGoogleServices(16).setDevice("angler")
-						.setSdkVersion(23).setModel("angler").setManufacturer("Samsung")
+						.setSdkVersion(23).setModel("angler").setManufacturer("Huawei")
 						.setBuildProduct("angler").setOtaInstalled(false)).setLastCheckinMsec(0)
 				.setCellOperator("310260").setSimOperator("310260").setRoaming("mobile-notroaming")
 				.setUserNumber(0)).setLocale("en_US").setTimeZone("Europe/Amsterdam").setVersion(3)

--- a/src/main/java/com/akdeniz/googleplaycrawler/Utils.java
+++ b/src/main/java/com/akdeniz/googleplaycrawler/Utils.java
@@ -31,9 +31,9 @@ import com.akdeniz.googleplaycrawler.misc.Base64;
 import com.akdeniz.googleplaycrawler.misc.DummyX509TrustManager;
 
 /**
- * 
+ *
  * @author akdeniz
- * 
+ *
  */
 public class Utils {
 
@@ -74,7 +74,7 @@ public class Utils {
 
     /**
      * Encrypts given string with Google Public Key.
-     * 
+     *
      */
     public static String encryptString(String str2Encrypt) throws Exception {
 
@@ -108,7 +108,7 @@ public class Utils {
 
     /**
      * Reads all contents of the input stream.
-     * 
+     *
      */
     public static byte[] readAll(InputStream inputStream) throws IOException {
 
@@ -156,7 +156,7 @@ public class Utils {
 
     /**
      * Generates android checkin request with properties of "Galaxy S3".
-     * 
+     *
      * <a href=
      * "http://www.glbenchmark.com/phonedetails.jsp?benchmark=glpro25&D=Samsung+GT-I9300+Galaxy+S+III&testgroup=system"
      * > http://www.glbenchmark.com/phonedetails.jsp?benchmark=glpro25&D=Samsung
@@ -172,14 +172,14 @@ public class Utils {
 				.newBuilder()
 				.setBuild(
 					AndroidBuildProto.newBuilder()
-						.setId("samsung/m0xx/m0:4.0.4/IMM76D/I9300XXALF2:user/release-keys")
-						.setProduct("smdk4x12").setCarrier("Google").setRadio("I9300XXALF2")
-						.setBootloader("PRIMELA03").setClient("android-google")
-						.setTimestamp(new Date().getTime() / 1000).setGoogleServices(16).setDevice("m0")
-						.setSdkVersion(21).setModel("GT-I9300").setManufacturer("Samsung")
-						.setBuildProduct("m0xx").setOtaInstalled(false)).setLastCheckinMsec(0)
+						.setId("google/angler/angler:6.0.1/MTC19T/2741993:user/release-keys")
+						.setProduct("angler").setCarrier("Google").setRadio("angler-03.61")
+						.setBootloader("angler-03.51").setClient("android-google")
+						.setTimestamp(new Date().getTime() / 1000).setGoogleServices(16).setDevice("angler")
+						.setSdkVersion(23).setModel("angler").setManufacturer("Samsung")
+						.setBuildProduct("angler").setOtaInstalled(false)).setLastCheckinMsec(0)
 				.setCellOperator("310260").setSimOperator("310260").setRoaming("mobile-notroaming")
-				.setUserNumber(0)).setLocale("en_US").setTimeZone("Europe/Istanbul").setVersion(3)
+				.setUserNumber(0)).setLocale("en_US").setTimeZone("Europe/Amsterdam").setVersion(3)
 		.setDeviceConfiguration(getDeviceConfigurationProto()).setFragment(0).build();
     }
 
@@ -192,32 +192,34 @@ public class Utils {
 		.setScreenLayout(2)
 		.setHasHardKeyboard(false)
 		.setHasFiveWayNavigation(false)
-		.setScreenDensity(320)
+		.setScreenDensity(560)
 		.setGlEsVersion(131072)
 		.addAllSystemSharedLibrary(
 			Arrays.asList("android.test.runner", "com.android.future.usb.accessory", "com.android.location.provider",
-				"com.android.nfc_extras", "com.google.android.maps", "com.google.android.media.effects",
+				"com.android.media.remotedisplay", "com.android.mediadrm.signer", "com.android.nfc_extras", "com.google.android.camera.experimental2015",
+				"com.google.android.dialer.support", "com.google.android.maps", "com.google.android.media.effects",
 				"com.google.widevine.software.drm", "javax.obex"))
 		.addAllSystemAvailableFeature(
-			Arrays.asList("android.hardware.bluetooth", "android.hardware.camera",
-				"android.hardware.camera.autofocus", "android.hardware.camera.flash",
-				"android.hardware.camera.front", "android.hardware.faketouch", "android.hardware.location",
-				"android.hardware.location.gps", "android.hardware.location.network",
-				"android.hardware.microphone", "android.hardware.nfc", "android.hardware.screen.landscape",
-				"android.hardware.screen.portrait", "android.hardware.sensor.accelerometer",
-				"android.hardware.sensor.barometer", "android.hardware.sensor.compass",
-				"android.hardware.sensor.gyroscope", "android.hardware.sensor.light",
-				"android.hardware.sensor.proximity", "android.hardware.telephony",
-				"android.hardware.telephony.gsm", "android.hardware.touchscreen",
-				"android.hardware.touchscreen.multitouch", "android.hardware.touchscreen.multitouch.distinct",
-				"android.hardware.touchscreen.multitouch.jazzhand", "android.hardware.usb.accessory",
-				"android.hardware.usb.host", "android.hardware.wifi", "android.hardware.wifi.direct",
-				"android.software.live_wallpaper", "android.software.sip", "android.software.sip.voip",
-				"com.cyanogenmod.android", "com.cyanogenmod.nfc.enhanced",
-				"com.google.android.feature.GOOGLE_BUILD", "com.nxp.mifare", "com.tmobile.software.themes"))
-		.addAllNativePlatform(Arrays.asList("armeabi-v7a", "armeabi"))
-		.setScreenWidth(720)
-		.setScreenHeight(1184)
+			Arrays.asList("android.hardware.audio.low_latency", "android.hardware.audio.output", "android.hardware.audio.pro", "android.hardware.microphone",
+				"android.hardware.output", "android.hardware.bluetooth", "android.hardware.bluetooth_le", "android.hardware.camera",
+				"android.hardware.camera.any", "android.hardware.camera.autofocus", "android.hardware.camera.flash", "android.hardware.camera.front",
+				"android.hardware.camera.level.full", "android.hardware.camera.capability.manual_sensor", "android.hardware.camera.capability.manual_post_processing", "android.hardware.camera.capability.raw",
+				"android.hardware.consumerir", "android.hardware.ethernet", "android.hardware.fingerprint", "android.hardware.location",
+				"android.hardware.location.network", "android.hardware.location.gps", "android.hardware.microphone", "android.hardware.nfc",
+				"android.hardware.nfc.hce", "android.hardware.sensor.accelerometer", "android.hardware.sensor.barometer", "android.hardware.sensor.compass",
+				"android.hardware.sensor.gyroscope", "android.hardware.sensor.hifi_sensors", "android.hardware.sensor.light", "android.hardware.sensor.proximity",
+				"android.hardware.sensor.stepcounter", "android.hardware.sensor.stepdetector", "android.hardware.screen.landscape", "android.hardware.screen.portrait",
+				"android.hardware.telephony", "android.hardware.telephony.cdma", "android.hardware.telephony.gsm", "android.hardware.faketouch",
+				"android.hardware.touchscreen", "android.hardware.touchscreen.multitouch", "android.hardware.touchscreen.multitouch.distinct", "android.hardware.touchscreen.multitouch.jazzhand",
+				"android.hardware.usb.host", "android.hardware.usb.accessory", "android.hardware.wifi", "android.hardware.wifi.direct",
+				"android.software.app_widgets", "android.software.backup", "android.software.connectionservice", "android.software.device_admin",
+				"android.software.home_screen", "android.software.input_methods", "android.software.live_wallpaper", "android.software.managed_users",
+				"android.software.midi", "android.software.print", "android.software.sip", "android.software.sip.voip",
+				"android.software.verified_boot", "android.software.voice_recognizers", "android.software.webview", "com.google.android.feature.GOOGLE_BUILD",
+				"com.google.android.feature.GOOGLE_EXPERIENCE", "com.google.android.feature.EXCHANGE_6_2", "com.nxp.mifare"))
+		.addAllNativePlatform(Arrays.asList("x86_64", "x86", "arm64-v8a", "armeabi-v7a", "armeabi"))
+		.setScreenWidth(1440)
+		.setScreenHeight(2560)
 		.addAllSystemSupportedLocale(
 			Arrays.asList("af", "af_ZA", "am", "am_ET", "ar", "ar_EG", "bg", "bg_BG", "ca", "ca_ES", "cs", "cs_CZ",
 				"da", "da_DK", "de", "de_AT", "de_CH", "de_DE", "de_LI", "el", "el_GR", "en", "en_AU", "en_CA",

--- a/src/main/java/com/akdeniz/googleplaycrawler/Utils.java
+++ b/src/main/java/com/akdeniz/googleplaycrawler/Utils.java
@@ -193,7 +193,7 @@ public class Utils {
 		.setHasHardKeyboard(false)
 		.setHasFiveWayNavigation(false)
 		.setScreenDensity(560)
-		.setGlEsVersion(131072)
+		.setGlEsVersion(196609)
 		.addAllSystemSharedLibrary(
 			Arrays.asList("android.test.runner", "com.android.future.usb.accessory", "com.android.location.provider",
 				"com.android.media.remotedisplay", "com.android.mediadrm.signer", "com.android.nfc_extras", "com.google.android.camera.experimental2015",

--- a/src/main/java/de/onyxbits/dummydroid/CheckinWorker.java
+++ b/src/main/java/de/onyxbits/dummydroid/CheckinWorker.java
@@ -2,7 +2,10 @@ package de.onyxbits.dummydroid;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Properties;
 
 import javax.swing.SwingWorker;
 
@@ -12,6 +15,12 @@ import com.akdeniz.googleplaycrawler.GooglePlay.ResponseWrapper;
 import com.akdeniz.googleplaycrawler.GooglePlay.UploadDeviceConfigRequest;
 import com.akdeniz.googleplaycrawler.GooglePlayAPI;
 import com.akdeniz.googleplaycrawler.Utils;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.HttpClient;
+import org.apache.http.conn.params.ConnRoutePNames;
+import org.apache.http.impl.client.DefaultHttpClient;
 
 /**
  * A swingworker for uploading the checkinrequest to Play and getting a GSF ID.
@@ -24,14 +33,45 @@ class CheckinWorker extends SwingWorker<String, Object> {
 	private FormData formData;
 	private CheckinForm callback;
 
+	/**
+	 * Name of the file containing the network config
+	 */
+	public static final String NETCFG = "network.cfg";
+	public static final String PROXYHOST = "proxyhost";
+	public static final String PROXYPORT = "proxyport";
+	public static final String PROXYUSER = "proxyuser";
+	public static final String PROXYPASS = "proxypass";
+
 	public CheckinWorker(CheckinForm callback, FormData formData) {
 		this.formData = formData;
 		this.callback = callback;
 	}
 
+	protected void setProxy(HttpClient client) throws IOException {
+		File cfgfile = new File(NETCFG);
+		if (cfgfile.exists()) {
+			Properties cfg = new Properties();
+			cfg.load(new FileInputStream(cfgfile));
+			String ph = cfg.getProperty(PROXYHOST, null);
+			String pp = cfg.getProperty(PROXYPORT, null);
+			String pu = cfg.getProperty(PROXYUSER, null);
+			String pw = cfg.getProperty(PROXYPASS, null);
+			if (ph == null || pp == null) {
+				return;
+			}
+			final HttpHost proxy = new HttpHost(ph, Integer.parseInt(pp));
+			client.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+			if (pu != null && pw != null) {
+				((DefaultHttpClient) client).getCredentialsProvider().setCredentials(
+						new AuthScope(proxy), new UsernamePasswordCredentials(pu, pw));
+			}
+		}
+	}
+
 	@Override
 	protected String doInBackground() throws Exception {
 		GooglePlayAPI api = new GooglePlayAPI(formData.getUsername(), formData.getPassword());
+		setProxy(api.getClient());
 		// this first checkin is for generating android-id
 		AndroidCheckinResponse checkinResponse = api.postCheckin(Utils.generateAndroidCheckinRequest()
 				.toByteArray());

--- a/src/main/java/de/onyxbits/dummydroid/CheckinWorker.java
+++ b/src/main/java/de/onyxbits/dummydroid/CheckinWorker.java
@@ -24,9 +24,9 @@ import org.apache.http.impl.client.DefaultHttpClient;
 
 /**
  * A swingworker for uploading the checkinrequest to Play and getting a GSF ID.
- * 
+ *
  * @author patrick
- * 
+ *
  */
 class CheckinWorker extends SwingWorker<String, Object> {
 
@@ -75,7 +75,7 @@ class CheckinWorker extends SwingWorker<String, Object> {
 		// this first checkin is for generating android-id
 		AndroidCheckinResponse checkinResponse = api.postCheckin(Utils.generateAndroidCheckinRequest()
 				.toByteArray());
-		api.setAndroidID(BigInteger.valueOf(checkinResponse.getAndroidId()).toString(16));
+		api.setAndroidID(BigInteger.valueOf(checkinResponse.getAndroidId()).toString(16).toUpperCase());
 		api.setSecurityToken((BigInteger.valueOf(checkinResponse.getSecurityToken()).toString(16)));
 
 		String c2dmAuth = api.loginAC2DM();
@@ -98,7 +98,7 @@ class CheckinWorker extends SwingWorker<String, Object> {
 				request.toByteArray(), "application/x-protobuf");
 		responseWrapper.getPayload().getUploadDeviceConfigResponse();
 
-		PrintWriter pw = new PrintWriter(new File(api.getAndroidID()+".txt"));
+		PrintWriter pw = new PrintWriter(new File(api.getAndroidID().toUpperCase()+".txt"));
 		pw.println(formData.assemble());
 		pw.close();
 		return api.getAndroidID();

--- a/src/main/java/de/onyxbits/dummydroid/FormData.java
+++ b/src/main/java/de/onyxbits/dummydroid/FormData.java
@@ -11,9 +11,9 @@ import com.akdeniz.googleplaycrawler.GooglePlay.DeviceConfigurationProto;
 
 /**
  * A datacapsule
- * 
+ *
  * @author patrick
- * 
+ *
  */
 public class FormData {
 
@@ -89,37 +89,34 @@ public class FormData {
 					.setScreenLayout(2)
 					.setHasHardKeyboard(false)
 					.setHasFiveWayNavigation(false)
-					.setScreenDensity(320)
-					.setScreenWidth(720)
-					.setScreenHeight(1184)
-					.setGlEsVersion(131072)
+					.setScreenDensity(560)
+					.setScreenWidth(1440)
+					.setScreenHeight(2560)
+					.setGlEsVersion(196609)
 					.addAllSystemSharedLibrary(
-							Arrays.asList("android.test.runner", "com.android.future.usb.accessory",
-									"com.android.location.provider", "com.android.nfc_extras",
-									"com.google.android.maps", "com.google.android.media.effects",
+							Arrays.asList("android.test.runner", "com.android.future.usb.accessory", "com.android.location.provider",
+									"com.android.media.remotedisplay", "com.android.mediadrm.signer", "com.android.nfc_extras", "com.google.android.camera.experimental2015",
+									"com.google.android.dialer.support", "com.google.android.maps", "com.google.android.media.effects",
 									"com.google.widevine.software.drm", "javax.obex"))
 					.addAllSystemAvailableFeature(
-							Arrays.asList("android.hardware.bluetooth", "android.hardware.camera",
-									"android.hardware.camera.autofocus", "android.hardware.camera.flash",
-									"android.hardware.camera.front", "android.hardware.faketouch",
-									"android.hardware.location", "android.hardware.location.gps",
-									"android.hardware.location.network", "android.hardware.microphone",
-									"android.hardware.nfc", "android.hardware.screen.landscape",
-									"android.hardware.screen.portrait", "android.hardware.sensor.accelerometer",
-									"android.hardware.sensor.barometer", "android.hardware.sensor.compass",
-									"android.hardware.sensor.gyroscope", "android.hardware.sensor.light",
-									"android.hardware.sensor.proximity", "android.hardware.telephony",
-									"android.hardware.telephony.gsm", "android.hardware.touchscreen",
-									"android.hardware.touchscreen.multitouch",
-									"android.hardware.touchscreen.multitouch.distinct",
-									"android.hardware.touchscreen.multitouch.jazzhand",
-									"android.hardware.usb.accessory", "android.hardware.usb.host",
-									"android.hardware.wifi", "android.hardware.wifi.direct",
-									"android.software.live_wallpaper", "android.software.sip",
-									"android.software.sip.voip", "com.cyanogenmod.android",
-									"com.cyanogenmod.nfc.enhanced", "com.google.android.feature.GOOGLE_BUILD",
-									"com.nxp.mifare", "com.tmobile.software.themes"))
-					.addAllNativePlatform(Arrays.asList("armeabi-v7a", "armeabi"))
+							Arrays.asList("android.hardware.audio.low_latency", "android.hardware.audio.output", "android.hardware.audio.pro", "android.hardware.microphone",
+									"android.hardware.output", "android.hardware.bluetooth", "android.hardware.bluetooth_le", "android.hardware.camera",
+									"android.hardware.camera.any", "android.hardware.camera.autofocus", "android.hardware.camera.flash", "android.hardware.camera.front",
+									"android.hardware.camera.level.full", "android.hardware.camera.capability.manual_sensor", "android.hardware.camera.capability.manual_post_processing", "android.hardware.camera.capability.raw",
+									"android.hardware.consumerir", "android.hardware.ethernet", "android.hardware.fingerprint", "android.hardware.location",
+									"android.hardware.location.network", "android.hardware.location.gps", "android.hardware.microphone", "android.hardware.nfc",
+									"android.hardware.nfc.hce", "android.hardware.sensor.accelerometer", "android.hardware.sensor.barometer", "android.hardware.sensor.compass",
+									"android.hardware.sensor.gyroscope", "android.hardware.sensor.hifi_sensors", "android.hardware.sensor.light", "android.hardware.sensor.proximity",
+									"android.hardware.sensor.stepcounter", "android.hardware.sensor.stepdetector", "android.hardware.screen.landscape", "android.hardware.screen.portrait",
+									"android.hardware.telephony", "android.hardware.telephony.cdma", "android.hardware.telephony.gsm", "android.hardware.faketouch",
+									"android.hardware.usb.host", "android.hardware.usb.accessory", "android.hardware.wifi", "android.hardware.wifi.direct",
+									"android.hardware.touchscreen", "android.hardware.touchscreen.multitouch", "android.hardware.touchscreen.multitouch.distinct", "android.hardware.touchscreen.multitouch.jazzhand",
+									"android.software.app_widgets", "android.software.backup", "android.software.connectionservice", "android.software.device_admin",
+									"android.software.home_screen", "android.software.input_methods", "android.software.live_wallpaper", "android.software.managed_users",
+									"android.software.midi", "android.software.print", "android.software.sip", "android.software.sip.voip",
+									"android.software.verified_boot", "android.software.voice_recognizers", "android.software.webview", "com.google.android.feature.GOOGLE_BUILD",
+									"com.google.android.feature.GOOGLE_EXPERIENCE", "com.google.android.feature.EXCHANGE_6_2", "com.nxp.mifare"))
+					.addAllNativePlatform(Arrays.asList("x86_64", "x86", "arm64-v8a", "armeabi-v7a", "armeabi"))
 					.addAllSystemSupportedLocale(
 							Arrays.asList("af", "af_ZA", "am", "am_ET", "ar", "ar_EG", "bg", "bg_BG", "ca",
 									"ca_ES", "cs", "cs_CZ", "da", "da_DK", "de", "de_AT", "de_CH", "de_DE", "de_LI",


### PR DESCRIPTION
Updated the user-agent to (at that moment) latest Angler device
Show the AndroidID capitalized to the user (in general it is used in this form in other locations, and more common way to show hex)
Updated the device defaults to be the most supreme device possible (with the exception of leanback/android TV 'features'), With the idea it is easier for users to remove than to add lines. (Thought: it might be cool to offer features described in the android docs 'checkbox' fields?)
Added the oauth hack with sdk17
Added the possibility to add devices on brand new accounts that had no devices registered yet (was otherwise not possible)
